### PR TITLE
Add minified main files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "build": "cd scripts && ./build.sh"
   },
-  "main": "dist/vue2-leaflet.js",
-  "module": "dist/vue2-leaflet.js",
-  "unpkg": "dist/vue2-leaflet.js",
+  "main": "dist/vue2-leaflet.min.js",
+  "module": "dist/vue2-leaflet.min.js",
+  "unpkg": "dist/vue2-leaflet.min.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/KoRiGaN/Vue2Leaflet.git"


### PR DESCRIPTION
With this loaders list for webpack@2.4.1:
```javascript
// ...
module: {
  rules: {
    { test: /\.jsx?$/, loader: 'source-map-loader', enforce: 'pre' },
    {
      test: /\.jsx?$/,
      loader: 'babel-loader',
      exclude: /(node_modules|bower_components)/,
      query: {
        presets: ['env'],
        babelrc: false,
      }
    },
    // ...
  }
}
// ...
```

exception thrown:
```
Message:
    ./~/vue2-leaflet/dist/vue2-leaflet.js
Module parse failed: /path/to/my-project/node_modules/source-map-loader/index.js!/path/to/my-project/node_modules/vue2-leaflet/dist/vue2-leaflet.js Unterminated string constant (444:5)
You may need an appropriate loader to handle this file type.
| /***/ (function(module, exports) {
| 
| eval("module.exports = __WEBPACK_EXTERNAL_MODULE_57__;\n
| /***/ })
| /******/ ]);
 @ ./~/babel-loader/lib!./~/vue-loader/lib/selector.js?type=script&index=0!./src/js/app/components/main-map/index.vue 63:0-38
 @ ./src/js/app/components/main-map/index.vue
 @ ./~/babel-loader/lib!./~/vue-loader/lib/selector.js?type=script&index=0!./src/js/app/views/home/index.vue
 @ ./src/js/app/views/home/index.vue
 @ ./src/js/app/router/routes.js
 @ ./src/js/app/router/index.js
 @ ./src/js/app/index.js
 @ ./src/js/main.js
 @ multi ./js/main.js
```

If I removing `source-map-loader` from rules list, library gets into the final build as follows:
![](https://habrastorage.org/files/6f8/10e/5c6/6f810e5c623a4234b1107dace1727584.png)

Such code can not be compressed and it is not possible to extract source maps.

This commit resolve this problem