### PR TITLE
Fix watching marker options

### DIFF
--- a/src/components/Marker.vue
+++ b/src/components/Marker.vue
@@ -51,6 +51,7 @@ const props = {
     custom: false,
   },
   options: {
+    custom: true,
     type: Object,
     default: () => ({}),
   },
@@ -89,6 +90,9 @@ export default {
       if (this.mapObject.dragging) {
         newVal ? this.mapObject.dragging.enable() : this.mapObject.dragging.disable();
       }
+    },
+    setOptions(newVal) {
+      Object.assign(this.options, newVal);
     },
     setVisible(newVal, oldVal) {
       if (newVal == oldVal) return;


### PR DESCRIPTION
As you can see [on this example](https://jsfiddle.net/erq8ehqh/), after map drag console displays:

    leafletElement[setMethodName] is not a function

due to missing `setOptions` method on Leaflet side. So here's quick fix.