### PR TITLE
Take the options from VTileLayer's options

### DIFF
--- a/src/components/TileLayer.vue
+++ b/src/components/TileLayer.vue
@@ -51,7 +51,7 @@ const props = {
 export default {
   props: props,
   mounted() {
-    const options = {};
+    const options = this.options;
     const otherPropertytoInitialize = [ "attribution", "token", "opacity", "zIndex" ];
     for (var i = 0; i < otherPropertytoInitialize.length; i++) {
       const propName = otherPropertytoInitialize[i];


### PR DESCRIPTION
This fixes the bug #92 that options passed to `VTileLayer` via the `:options` binding were being ignored.