### PR TITLE
Allow specifying a custom TileLayer class

### DIFF
--- a/src/components/TileLayer.vue
+++ b/src/components/TileLayer.vue
@@ -50,6 +50,10 @@ const props = {
     default: function() {
       return {};
     }
+  },
+  tileLayerClass: {
+  	type: Object,
+	default: L.tileLayer
   }
 };
 
@@ -64,7 +68,7 @@ export default {
         options[propName] = this[propName];
       }
     }
-    this.mapObject = L.tileLayer(this.url, options);
+    this.mapObject = this.tileLayerClass(this.url, options);
     eventsBinder(this, this.mapObject, events);
     propsBinder(this, this.mapObject, props);
   },

--- a/src/components/TileLayer.vue
+++ b/src/components/TileLayer.vue
@@ -52,7 +52,7 @@ const props = {
     }
   },
   tileLayerClass: {
-  	type: Object,
+  	type: Function,
 	default: L.tileLayer
   }
 };


### PR DESCRIPTION
Specifying a custom TileLayer class is useful for integrating 3rd party TileLayers while keeping the nice Vue-semantics of Vue2Leaflet. 

For example, we're using this change to support leaflet.offline tilelayers.