### PR TITLE
Declare Vue as a Peer Dependecy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5088,11 +5088,6 @@
         "indexof": "0.0.1"
       }
     },
-    "vue": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.3.tgz",
-      "integrity": "sha512-C8O5ZtR9jpwm6sCre3k42/WvuAcil5hH1+c3mJks8kNCYKh57sQh6I5U7m9L0fD89OKkIofmebUORngZkLedNA=="
-    },
     "vue-loader": {
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-13.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "url": "git://github.com/KoRiGaN/Vue2Leaflet.git"
   },
   "dependencies": {
-    "leaflet": "^1.2.0",
+    "leaflet": "^1.2.0"
+  },
+  "peerDependencies": {
     "vue": "^2.5.3"
   },
   "keywords": [

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script>
-import Vue from 'vue'
 import L from 'leaflet';
 import eventsBinder from '../utils/eventsBinder.js';
 import propsBinder from '../utils/propsBinder.js';


### PR DESCRIPTION
When I'm using this library in my Nuxt.Js project, the project doesn't run anymore. Installing `Vue2Leaflet` also install a different version of Vue.Js that Nuxt uses, causing a version-mismatch in the project between the different core Vue.Js libraries.

The solution is to declare Vue as a peer dependency (more information [here](https://nodejs.org/en/blog/npm/peer-dependencies/)).

I also removed a useless Vue.Js import