### PR TITLE
documentation: reference to mapObject in mounted

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ Then in you JavaScript you can use mapObject which is Leaflet map instance :
 ``` javascript
 this.$refs.map.mapObject;
 ```
+
+**Note:** `mapObject` is not available directly in vue's `mounted` hook. You need to wrap the call to `this.$refs.map` in a `nextTick` call:
+
+``` javascript
+data: () => ({map: null}),
+mounted () {
+  // DON'T
+  this.map = this.$refs.map.mapObject // doesn't work, this.map is null
+
+  // DO
+  this.$nextTick(() => {
+    this.map = this.$refs.map.mapObject // work as expected
+  })
+},
+```
+
 This also work for any other component (Marker, Polyline, etc...)
 
 #### How can I bind events of Vue2Leaflet components?


### PR DESCRIPTION
I struggled to find a way to get a reference to the mapObject in the mounted hook, so I though I'd share the solution in the documentation ;)