### PR TITLE
add layerType and name props in LLayerGroup

### DIFF
--- a/examples/src/components/Example.vue
+++ b/examples/src/components/Example.vue
@@ -110,7 +110,7 @@
       :min-zoom="minZoom"
       :max-zoom="maxZoom"
       style="height: 45%">
-      <l-control-layers :position="layersPosition"/>
+      <l-control-layers :position="layersPosition" :collapsed="false" />
       <l-tile-layer
         v-for="tileProvider in tileProviders"
         :key="tileProvider.name"
@@ -145,7 +145,10 @@
       <l-layer-group
         v-for="item in stuff"
         :key="item.id"
-        :visible="item.visible" >
+        :visible="item.visible"
+        layerType="overlay"
+        name="Layer 1"
+        >
         <l-layer-group :visible="item.markersVisible" >
           <l-marker
             v-for="marker in item.markers"

--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -13,6 +13,14 @@ const props = {
     type: Boolean,
     custom: true,
     default: true
+  },
+  layerType: {
+    type: String,
+    custom: true
+  },
+  name: {
+    type: String,
+    custom: true
   }
 };
 
@@ -56,6 +64,20 @@ export default {
         this.parentContainer.addLayer(this);
       } else {
         this.parentContainer.removeLayer(this);
+      }
+    },
+    setName(newVal, oldVal) {
+      if (newVal === oldVal) return;
+      this.parentContainer.removeLayer(this);
+      if (this.visible) {
+        this.parentContainer.addLayer(this);
+      }
+    },
+    setLayerType(newVal, oldVal) {
+      if (newVal === oldVal) return;
+      this.parentContainer.removeLayer(this);
+      if (this.visible) {
+        this.parentContainer.addLayer(this);
       }
     }
   }


### PR DESCRIPTION
I added layerType and name for LLayerGroup.
After this change LControlLayers can show group layer if set name and type ('overlay' for example).
Need merge [this fix](https://github.com/KoRiGaN/Vue2Leaflet/pull/229) for examples.
![layers-control](https://user-images.githubusercontent.com/5105017/46013855-1bfe8700-c0d6-11e8-91be-4aa5de948583.PNG)
