### PR TITLE
Fix/options merging

### DIFF
--- a/src/components/LCircle.vue
+++ b/src/components/LCircle.vue
@@ -25,7 +25,7 @@ export default {
     };
   },
   mounted () {
-    const options = optionsMerger(this.circleOptions, this.options);
+    const options = optionsMerger(this.circleOptions, this);
     this.mapObject = L.circle(this.latLng, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LCircle.vue
+++ b/src/components/LCircle.vue
@@ -7,6 +7,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Circle from '../mixins/Circle.js';
 
 export default {
@@ -24,7 +25,8 @@ export default {
     };
   },
   mounted () {
-    this.mapObject = L.circle(this.latLng, this.circleOptions);
+    const options = optionsMerger(this.circleOptions, this.options);
+    this.mapObject = L.circle(this.latLng, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.ready = true;

--- a/src/components/LCircleMarker.vue
+++ b/src/components/LCircleMarker.vue
@@ -25,7 +25,7 @@ export default {
     };
   },
   mounted () {
-    const options = optionsMerger(this.circleOptions, this.options);
+    const options = optionsMerger(this.circleOptions, this);
     this.mapObject = L.circleMarker(this.latLng, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LCircleMarker.vue
+++ b/src/components/LCircleMarker.vue
@@ -7,6 +7,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Circle from '../mixins/Circle.js';
 
 export default {
@@ -24,7 +25,8 @@ export default {
     };
   },
   mounted () {
-    this.mapObject = L.circleMarker(this.latLng, this.circleOptions);
+    const options = optionsMerger(this.circleOptions, this.options);
+    this.mapObject = L.circleMarker(this.latLng, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.ready = true;

--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -23,7 +23,7 @@ export default {
         this.element = el;
       }
     });
-    const options = optionsMerger(this.controlOptions, this.options);
+    const options = optionsMerger(this.controlOptions, this);
     this.mapObject = new LControl(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);

--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -7,6 +7,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Control from '../mixins/Control.js';
 
 export default {
@@ -22,7 +23,8 @@ export default {
         this.element = el;
       }
     });
-    this.mapObject = new LControl(this.controlOptions);
+    const options = optionsMerger(this.controlOptions, this.options);
+    this.mapObject = new LControl(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);
     this.mapObject.setElement(this.$el);

--- a/src/components/LControlAttribution.vue
+++ b/src/components/LControlAttribution.vue
@@ -1,5 +1,6 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Control from '../mixins/Control';
 
 export default {
@@ -8,15 +9,15 @@ export default {
   props: {
     prefix: {
       type: String,
-      default: 'Leaflet'
+      default: null
     }
   },
   mounted () {
-    this.attributionControlOptions = {
+    const options = optionsMerger({
       ...this.controlOptions,
       prefix: this.prefix
-    };
-    this.mapObject = L.control.attribution(this.attributionControlOptions);
+    }, this.options);
+    this.mapObject = L.control.attribution(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.mapObject.addTo(this.$parent.mapObject);
   },

--- a/src/components/LControlAttribution.vue
+++ b/src/components/LControlAttribution.vue
@@ -16,7 +16,7 @@ export default {
     const options = optionsMerger({
       ...this.controlOptions,
       prefix: this.prefix
-    }, this.options);
+    }, this);
     this.mapObject = L.control.attribution(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.mapObject.addTo(this.$parent.mapObject);

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -36,7 +36,7 @@ export default {
       hideSingleBase: this.hideSingleBase,
       sortLayers: this.sortLayers,
       sortFunction: this.sortFunction
-    }, this.options);
+    }, this);
     this.mapObject = L.control.layers(null, null, options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.$parent.registerLayerControl(this);

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -1,5 +1,6 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Control from '../mixins/Control.js';
 
 export default {
@@ -28,15 +29,15 @@ export default {
     }
   },
   mounted () {
-    this.controlLayersOptions = {
+    const options = optionsMerger({
       ...this.controlOptions,
       collapsed: this.collapsed,
       autoZIndex: this.autoZIndex,
       hideSingleBase: this.hideSingleBase,
       sortLayers: this.sortLayers,
       sortFunction: this.sortFunction
-    };
-    this.mapObject = L.control.layers(null, null, this.controlLayersOptions);
+    }, this.options);
+    this.mapObject = L.control.layers(null, null, options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.$parent.registerLayerControl(this);
   },

--- a/src/components/LControlScale.vue
+++ b/src/components/LControlScale.vue
@@ -1,5 +1,6 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Control from '../mixins/Control.js';
 
 export default {
@@ -24,14 +25,14 @@ export default {
     }
   },
   mounted () {
-    this.controlScaleOptions = {
+    const options = optionsMerger({
       ...this.controlOptions,
       maxWidth: this.maxWidth,
       metric: this.metric,
       imperial: this.imperial,
       updateWhenIdle: this.updateWhenIdle
-    };
-    this.mapObject = L.control.scale(this.controlScaleOptions);
+    }, this.options);
+    this.mapObject = L.control.scale(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.mapObject.addTo(this.$parent.mapObject);
   },

--- a/src/components/LControlScale.vue
+++ b/src/components/LControlScale.vue
@@ -31,7 +31,7 @@ export default {
       metric: this.metric,
       imperial: this.imperial,
       updateWhenIdle: this.updateWhenIdle
-    }, this.options);
+    }, this);
     this.mapObject = L.control.scale(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.mapObject.addTo(this.$parent.mapObject);

--- a/src/components/LControlZoom.vue
+++ b/src/components/LControlZoom.vue
@@ -31,7 +31,7 @@ export default {
       zoomInTitle: this.zoomInTitle,
       zoomOutText: this.zoomOutText,
       zoomOutTitle: this.zoomOutTitle
-    }, this.options);
+    }, this);
     this.mapObject = L.control.zoom(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.mapObject.addTo(this.$parent.mapObject);

--- a/src/components/LControlZoom.vue
+++ b/src/components/LControlZoom.vue
@@ -1,5 +1,6 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Control from '../mixins/Control.js';
 
 export default {
@@ -24,14 +25,14 @@ export default {
     }
   },
   mounted () {
-    this.controlZoomOptions = {
+    const options = optionsMerger({
       ...this.controlOptions,
       zoomInText: this.zoomInText,
       zoomInTitle: this.zoomInTitle,
       zoomOutText: this.zoomOutText,
       zoomOutTitle: this.zoomOutTitle
-    };
-    this.mapObject = L.control.zoom(this.controlZoomOptions);
+    }, this.options);
+    this.mapObject = L.control.zoom(options);
     propsBinder(this, this.mapObject, this.$options.props);
     this.mapObject.addTo(this.$parent.mapObject);
   },

--- a/src/components/LGeoJson.vue
+++ b/src/components/LGeoJson.vue
@@ -30,7 +30,7 @@ export default {
       return optionsMerger({
         ...this.layerGroupOptions,
         style: this.optionsStyle
-      }, this.options);
+      }, this);
     }
   },
   mounted () {

--- a/src/components/LGeoJson.vue
+++ b/src/components/LGeoJson.vue
@@ -1,6 +1,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import L from 'leaflet';
 import LayerGroup from '../mixins/LayerGroup.js';
 
@@ -26,11 +27,10 @@ export default {
   },
   computed: {
     mergedOptions () {
-      return {
+      return optionsMerger({
         ...this.layerGroupOptions,
-        ...this.options,
-        style: this.optionsStyle || this.options.style
-      };
+        style: this.optionsStyle
+      }, this.options);
     }
   },
   mounted () {

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -8,7 +8,7 @@ export default {
   name: 'LImageOverlay',
   mixins: [ImageOverlay],
   mounted () {
-    const options = optionsMerger(this.imageOverlayOptions, this.options);
+    const options = optionsMerger(this.imageOverlayOptions, this);
     this.mapObject = L.imageOverlay(this.url, this.bounds, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -1,13 +1,15 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import ImageOverlay from '../mixins/ImageOverlay.js';
 
 export default {
   name: 'LImageOverlay',
   mixins: [ImageOverlay],
   mounted () {
-    this.mapObject = L.imageOverlay(this.url, this.bounds, this.imageOverlayOptions);
+    const options = optionsMerger(this.imageOverlayOptions, this.options);
+    this.mapObject = L.imageOverlay(this.url, this.bounds, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -93,8 +93,7 @@ export default {
       crs: this.crs,
       center: this.center,
       zoom: this.zoom
-    }, this.options);
-
+    }, this);
     this.mapObject = L.map(this.$el, options);
     this.setBounds(this.bounds);
     this.mapObject.on('moveend', debounce(this.moveEndHandler, 100));

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -8,6 +8,7 @@
 import L from 'leaflet';
 import propsBinder from '../utils/propsBinder.js';
 import debounce from '../utils/debounce.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 
 export default {
   name: 'LMap',
@@ -33,11 +34,11 @@ export default {
     },
     minZoom: {
       type: Number,
-      default: undefined
+      default: null
     },
     maxZoom: {
       type: Number,
-      default: undefined
+      default: null
     },
     paddingBottomRight: {
       type: Array,
@@ -65,7 +66,7 @@ export default {
     },
     maxBoundsViscosity: {
       type: Number,
-      default: 0
+      default: null
     },
     options: {
       type: Object,
@@ -83,8 +84,7 @@ export default {
     };
   },
   mounted () {
-    const options = {
-      ...this.options,
+    const options = optionsMerger({
       minZoom: this.minZoom,
       maxZoom: this.maxZoom,
       maxBounds: this.maxBounds,
@@ -93,7 +93,8 @@ export default {
       crs: this.crs,
       center: this.center,
       zoom: this.zoom
-    };
+    }, this.options);
+
     this.mapObject = L.map(this.$el, options);
     this.setBounds(this.bounds);
     this.mapObject.on('moveend', debounce(this.moveEndHandler, 100));

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -1,6 +1,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Layer from '../mixins/Layer.js';
 
 export default {
@@ -42,13 +43,12 @@ export default {
     };
   },
   mounted () {
-    const options = {
+    const options = optionsMerger({
       ...this.layerOptions,
-      ...this.options,
       icon: this.icon,
       zIndexOffset: this.zIndexOffset,
       draggable: this.draggable
-    };
+    }, this.options);
     this.mapObject = L.marker(this.latLng, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -48,7 +48,7 @@ export default {
       icon: this.icon,
       zIndexOffset: this.zIndexOffset,
       draggable: this.draggable
-    }, this.options);
+    }, this);
     this.mapObject = L.marker(this.latLng, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LPolygon.vue
+++ b/src/components/LPolygon.vue
@@ -25,7 +25,7 @@ export default {
     };
   },
   mounted () {
-    const options = optionsMerger(this.polygonOptions, this.options);
+    const options = optionsMerger(this.polygonOptions, this);
     this.mapObject = L.polygon(this.latLngs, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LPolygon.vue
+++ b/src/components/LPolygon.vue
@@ -7,6 +7,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Polygon from '../mixins/Polygon.js';
 
 export default {
@@ -24,7 +25,8 @@ export default {
     };
   },
   mounted () {
-    this.mapObject = L.polygon(this.latLngs, this.polygonOptions);
+    const options = optionsMerger(this.polygonOptions, this.options);
+    this.mapObject = L.polygon(this.latLngs, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.ready = true;

--- a/src/components/LPolyline.vue
+++ b/src/components/LPolyline.vue
@@ -25,7 +25,7 @@ export default {
     };
   },
   mounted () {
-    const options = optionsMerger(this.polyLineOptions, this.options);
+    const options = optionsMerger(this.polyLineOptions, this);
     this.mapObject = L.polyline(this.latLngs, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LPolyline.vue
+++ b/src/components/LPolyline.vue
@@ -7,6 +7,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Polyline from '../mixins/Polyline.js';
 
 export default {
@@ -24,7 +25,8 @@ export default {
     };
   },
   mounted () {
-    this.mapObject = L.polyline(this.latLngs, this.polyLineOptions);
+    const options = optionsMerger(this.polyLineOptions, this.options);
+    this.mapObject = L.polyline(this.latLngs, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.ready = true;

--- a/src/components/LPopup.vue
+++ b/src/components/LPopup.vue
@@ -1,6 +1,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Popper from '../mixins/Popper.js';
 
 export default {
@@ -13,7 +14,8 @@ export default {
     }
   },
   mounted () {
-    this.mapObject = L.popup(this.popperOptions);
+    const options = optionsMerger(this.popperOptions, this.options);
+    this.mapObject = L.popup(options);
     if (this.latLng !== undefined) {
       this.mapObject.setLatLng(this.latLng);
     }

--- a/src/components/LPopup.vue
+++ b/src/components/LPopup.vue
@@ -14,7 +14,7 @@ export default {
     }
   },
   mounted () {
-    const options = optionsMerger(this.popperOptions, this.options);
+    const options = optionsMerger(this.popperOptions, this);
     this.mapObject = L.popup(options);
     if (this.latLng !== undefined) {
       this.mapObject.setLatLng(this.latLng);

--- a/src/components/LRectangle.vue
+++ b/src/components/LRectangle.vue
@@ -7,6 +7,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Polygon from '../mixins/Polygon.js';
 
 export default {
@@ -24,7 +25,8 @@ export default {
     };
   },
   mounted () {
-    this.mapObject = L.rectangle(this.bounds, this.polygonOptions);
+    const options = optionsMerger(this.polygonOptions, this.options);
+    this.mapObject = L.rectangle(this.bounds, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.ready = true;

--- a/src/components/LRectangle.vue
+++ b/src/components/LRectangle.vue
@@ -25,7 +25,7 @@ export default {
     };
   },
   mounted () {
-    const options = optionsMerger(this.polygonOptions, this.options);
+    const options = optionsMerger(this.polygonOptions, this);
     this.mapObject = L.rectangle(this.bounds, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -6,6 +6,7 @@
 import L from 'leaflet';
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import TileLayer from '../mixins/TileLayer.js';
 
 export default {
@@ -22,7 +23,8 @@ export default {
     }
   },
   mounted () {
-    this.mapObject = this.tileLayerClass(this.url, this.tileLayerOptions);
+    const options = optionsMerger(this.tileLayerOptions, this.options);
+    this.mapObject = this.tileLayerClass(this.url, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -23,7 +23,7 @@ export default {
     }
   },
   mounted () {
-    const options = optionsMerger(this.tileLayerOptions, this.options);
+    const options = optionsMerger(this.tileLayerOptions, this);
     this.mapObject = this.tileLayerClass(this.url, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -8,7 +8,7 @@ export default {
   name: 'LTooltip',
   mixins: [Popper],
   mounted () {
-    const options = optionsMerger(this.popperOptions, this.options);
+    const options = optionsMerger(this.popperOptions, this);
     this.mapObject = L.tooltip(options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -1,13 +1,15 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import Popper from '../mixins/Popper.js';
 
 export default {
   name: 'LTooltip',
   mixins: [Popper],
   mounted () {
-    this.mapObject = L.tooltip(this.popperOptions);
+    const options = optionsMerger(this.popperOptions, this.options);
+    this.mapObject = L.tooltip(options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.mapObject.setContent(this.content || this.$el);

--- a/src/components/LWMSTileLayer.vue
+++ b/src/components/LWMSTileLayer.vue
@@ -14,7 +14,7 @@ export default {
     }
   },
   mounted () {
-    const options = optionsMerger(this.tileLayerWMSOptions, this.options);
+    const options = optionsMerger(this.tileLayerWMSOptions, this);
     this.mapObject = L.tileLayer.wms(this.baseUrl, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);

--- a/src/components/LWMSTileLayer.vue
+++ b/src/components/LWMSTileLayer.vue
@@ -1,6 +1,7 @@
 <script>
 import propsBinder from '../utils/propsBinder.js';
 import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
 import TileLayerWMS from '../mixins/TileLayerWMS.js';
 
 export default {
@@ -13,7 +14,8 @@ export default {
     }
   },
   mounted () {
-    this.mapObject = L.tileLayer.wms(this.baseUrl, this.tileLayerWMSOptions);
+    const options = optionsMerger(this.tileLayerWMSOptions, this.options);
+    this.mapObject = L.tileLayer.wms(this.baseUrl, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);

--- a/src/mixins/Control.js
+++ b/src/mixins/Control.js
@@ -11,7 +11,6 @@ export default {
   },
   mounted () {
     this.controlOptions = {
-      ...this.options,
       position: this.position
     };
   },

--- a/src/mixins/LayerGroup.js
+++ b/src/mixins/LayerGroup.js
@@ -10,7 +10,10 @@ export default {
     }
   },
   mounted () {
-    this.layerGroupOptions = {...this.layerOptions};
+    this.layerGroupOptions = {
+      ...this.layerOptions,
+      layerType: this.layerType
+    };
   },
   methods: {
     addLayer (layer, alreadyAdded) {

--- a/src/mixins/Path.js
+++ b/src/mixins/Path.js
@@ -90,6 +90,9 @@ export default {
     for (var i = 0; i < otherPropertytoInitialize.length; i++) {
       const propName = otherPropertytoInitialize[i];
       if (this[propName] !== undefined) {
+        if (this.pathOptions[propName] !== undefined && this.pathOptions[propName] !== null) {
+          console.warn(`${propName} defined in prop lStyle is being overridden by a direct prop`);
+        }
         this.pathOptions[propName] = this[propName];
       }
     }

--- a/src/mixins/Path.js
+++ b/src/mixins/Path.js
@@ -77,23 +77,22 @@ export default {
   },
   mounted () {
     this.pathOptions = {};
-    if (this.lStyle) {
-      console.warn('lStyle is deprecated and is going to be removed in the next major version');
-      for (var style in this.lStyle) {
-        this.pathOptions[style] = this.lStyle[style];
-      }
-    }
     const otherPropertytoInitialize = ['smoothFactor', 'noClip', 'stroke', 'color', 'weight',
       'opacity', 'lineCap', 'lineJoin', 'dashArray', 'dashOffset', 'fill', 'fillColor',
       'fillOpacity', 'fillRule', 'className'
     ];
+
     for (var i = 0; i < otherPropertytoInitialize.length; i++) {
       const propName = otherPropertytoInitialize[i];
-      if (this[propName] !== undefined) {
-        if (this.pathOptions[propName] !== undefined && this.pathOptions[propName] !== null) {
-          console.warn(`${propName} defined in prop lStyle is being overridden by a direct prop`);
-        }
+      if (this[propName] !== undefined && this.propName !== null) {
         this.pathOptions[propName] = this[propName];
+      }
+    }
+
+    if (this.lStyle) {
+      console.warn('lStyle is deprecated and is going to be removed in the next major version');
+      for (var style in this.lStyle) {
+        this.pathOptions[style] = this.lStyle[style];
       }
     }
   },

--- a/src/utils/optionsUtils.js
+++ b/src/utils/optionsUtils.js
@@ -9,16 +9,20 @@ export const collectionCleaner = (options) => {
   return result;
 };
 
-export const optionsMerger = (props, options) => {
-  options = options && options.constructor === Object ? options : {};
+export const optionsMerger = (props, instance) => {
+  const options = instance.options && instance.options.constructor === Object ? instance.options : {};
   props = props && props.constructor === Object ? props : {};
   const result = {...collectionCleaner(options)};
   props = collectionCleaner(props);
+  const defaultProps = instance.$options.props;
   for (let key in props) {
-    if (result[key]) {
+    const def = defaultProps[key] ? defaultProps[key].default : Symbol('unique');
+    if (result[key] && def !== props[key]) {
       console.warn(`${key} props is overriding the value passed in the options props`);
+      result[key] = props[key];
+    } else if (!result[key]) {
+      result[key] = props[key];
     }
-    result[key] = props[key];
   };
   return result;
 };

--- a/src/utils/optionsUtils.js
+++ b/src/utils/optionsUtils.js
@@ -1,0 +1,24 @@
+export const collectionCleaner = (options) => {
+  const result = {};
+  for (let key in options) {
+    const value = options[key];
+    if (value !== null && value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
+export const optionsMerger = (props, options) => {
+  options = options && options.constructor === Object ? options : {};
+  props = props && props.constructor === Object ? props : {};
+  const result = {...collectionCleaner(options)};
+  props = collectionCleaner(props);
+  for (let key in props) {
+    if (result[key]) {
+      console.warn(`${key} props is overriding the value passed in the options props`);
+    }
+    result[key] = props[key];
+  };
+  return result;
+};


### PR DESCRIPTION
@bezany can you take a look a this? 

the idea is to:

- remove all undefined and null from any props and options object
- merge them together giving the priority to props but emitting a warning if there is an override

Like this we will never pass an undefined value to leaflet letting it fill his own default and avoiding to break it and we will warn the user if an override is happening.

I prefer to give priority to props because they can be reactive, we have setter and getters and I think is a much more maintainable approach. Ultimately  I would like to get rid of the options prop completely ( at some point )  


fixes #251 