### PR TITLE
Fix default null/empty value

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -109,7 +109,7 @@ export default {
       for (var layer in this.layersToAdd) {
         this.layerControl.addLayer(layer);
       }
-      this.layersToAdd = null;
+      this.layersToAdd = [];
     },
     addLayer (layer, alreadyAdded) {
       if (layer.layerType !== undefined) {


### PR DESCRIPTION
removeLayer attempts to filter:
```
this.layersToAdd = this.layersToAdd.filter((l) => l.name !== layer.name);
```
Null value creates undefined error.