### PR TITLE
Bug Fix: #184 

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -151,6 +151,7 @@ export default {
         newLng = newVal.lng;
       }
       let center = this.lastSetCenter == null ? this.mapObject.getCenter() : this.lastSetCenter;
+      center = {...center};
       if (center.lat !== newLat || center.lng !== newLng) {
         center.lat = newVal.lat;
         center.lng = newVal.lng;


### PR DESCRIPTION
Fixes: #184 

**Bug:** If using a vuex store and mapping state to a computed property, vue2leaflet would modify properties of the computed property passed in and throw the error:
`Error: [vuex] Do not mutate vuex store state outside mutation handlers.`

**Fix:** Copy the center object so the lat/lng properties of the original object are not modified directly.
