### PR TITLE
Expose zoomControl to resolve #269

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -15,6 +15,10 @@ export default {
   name: 'LMap',
   mixins: [Options],
   props: {
+    zoomControl: {
+      type: Boolean,
+      default: true
+    },
     center: {
       type: [Object, Array],
       custom: true,
@@ -90,7 +94,8 @@ export default {
       worldCopyJump: this.worldCopyJump,
       crs: this.crs,
       center: this.center,
-      zoom: this.zoom
+      zoom: this.zoom,
+      zoomControl: this.zoomControl
     }, this);
     this.mapObject = L.map(this.$el, options);
     this.setBounds(this.bounds);


### PR DESCRIPTION
This PR exposes the Leaflet `zoomControl` option as a property `zoom-control` which is set to `true` by default. In order to set it to false (hide the zoom controls) do the following:

```html
<l-map :zoom-control="false" . . . ></l-map>
```

Resolves #269 