### PR TITLE
Bugfix Icon component

### DIFF
--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -106,7 +106,7 @@ export default {
 
   beforeDestroy () {
     if (this.parentContainer.mapObject) {
-      this.parentContainer.mapObject.setIcon(null);
+      this.parentContainer.mapObject.setIcon(this.parentContainer.$props.icon);
     }
 
     this.observer.disconnect();

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -127,7 +127,7 @@ export default {
 
     createIcon () {
       // If only html of a divIcon changed, we can just replace the DOM without the need of recreating the whole icon
-      if (this.htmlSwapNeeded && !this.recreationNeeded && this.iconObject) {
+      if (this.htmlSwapNeeded && !this.recreationNeeded && this.iconObject && this.parentContainer.mapObject.getElement()) {
         this.parentContainer.mapObject.getElement().innerHTML = this.$el.innerHTML;
 
         this.htmlSwapNeeded = false;


### PR DESCRIPTION
When the icon component inside a marker component is destroyed (because of a `v-if` on the icon f.e.), the marker should get a valid icon. Now it gets the icon from the marker icon prop assigned, so nothing breaks.