### PR TITLE
Add vue2-leaflet-gpx to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Leaflet plugins can easily work with Vue2Leaflet, if you want to use one I would
 * [vue2-leaflet-hotline](https://github.com/ikmolbo/vue2-leaflet-hotline) wrapper for [hotline](https://github.com/iosphere/Leaflet.hotline)
 * [vue2-leaflet-movingmarker](https://github.com/LouisMazel/vue2-leaflet-movingmarker) wrapper for [Leaflet.Marker.SlideTo](https://gitlab.com/IvanSanchez/Leaflet.Marker.SlideTo)
 * [vue2-leaflet-path-transform](https://github.com/imudin/vue2-leaflet-path-transform) wrapper for [Leaflet.Path.Transform ](https://github.com/w8r/Leaflet.Path.Transform)
+* [vue2-leaflet-gpx](https://github.com/tdcook/vue2-leaflet-gpx) wrapper for [leaflet-gpx](https://github.com/mpetazzoni/leaflet-gpx)
 
 If you have created a plugin and want it to be listed here, let me know :-).
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -50,3 +50,7 @@ wrapper for [Leaflet.Marker.SlideTo](https://gitlab.com/IvanSanchez/Leaflet.Mark
 ## [vue2-leaflet-path-transform](https://github.com/imudin/vue2-leaflet-path-transform)
 
 wrapper for [Leaflet.Path.Transform](https://github.com/w8r/Leaflet.Path.Transform)
+
+## [vue2-leaflet-gpx](https://github.com/tdcook/vue2-leaflet-gpx)
+
+wrapper for [leaflet-gpx](https://github.com/mpetazzoni/leaflet-gpx)


### PR DESCRIPTION
I've created a wrapper for the leaflet-gpx plugin. I'd like to have it added to the README. Thank you for your work on this project!