### PR TITLE
[RFC] Wrap Leaflet's GridLayer

### DIFF
--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -23,6 +23,7 @@ It's possible to bind to them by simply writing `@leafletEventName`
 
 ## Tiles
 
+* [l-grid-layer](/components/l-grid-layer/)
 * [l-tile-layer](/components/l-tile-layer/)
 * [l-wms-tile-layer](/components/l-wms-tile-layer/)
 

--- a/docs/components/_sidebar.md
+++ b/docs/components/_sidebar.md
@@ -7,6 +7,7 @@
 * [l-control-zoom](/components/l-control-zoom/)
 * [l-feature-group](/components/l-feature-group/)
 * [l-geo-json](/components/l-geo-json/)
+* [l-grid-layer](/components/l-grid-layer/)
 * [l-icon](/components/l-icon/)
 * [l-icon-default](/components/l-icon-default/)
 * [l-image-overlay](/components/l-image-overlay/)

--- a/docs/components/l-grid-layer/README.md
+++ b/docs/components/l-grid-layer/README.md
@@ -1,0 +1,87 @@
+# l-grid-layer
+
+Creates a map layer where each tile is an instanciated Vue component.
+Each tile component is given `coords` props by `l-grid-layer` to indicate
+the zoom level and position of the tile 
+(see https://leafletjs.com/examples/extending/extending-2-layers.html#lgridlayer-and-dom-elements).
+
+## Playground
+Any of the props of `l-grid-layer` or the classes that it extends can be used
+
+<vuep template="#grid-layer-example"></vuep>
+
+<script v-pre type="text/x-template" id="grid-layer-example">
+
+<template>
+  <l-map style="height: 100%; width: 100%" :zoom="zoom" :center="center" :options="{zoomControl: false}">
+    <l-tile-layer :url="url"></l-tile-layer>
+    <l-grid-layer :tileComponent="tileComponent"></l-grid-layer>
+  </l-map>
+</template>
+
+<script>
+
+Vue.component('l-map', Vue2Leaflet.LMap)
+Vue.component('l-tile-layer', Vue2Leaflet.LTileLayer)
+Vue.component('l-grid-layer', Vue2Leaflet.LGridLayer)
+
+export default {
+  data () {
+    return {
+      tileComponent: {
+        name: 'tile-component',
+        props: {
+          coords: {
+            type: Object,
+            required: true
+          }
+        },
+        template: '<div>Coords: {{coords.x}}, {{coords.y}}, {{coords.z}}</div>'
+      },
+      url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
+      zoom: 8,
+      center: [47.313220, -1.319482]
+    };
+  }
+}
+</script>
+</script>
+
+## Props
+
+```js
+{
+  tileComponent: {
+    type: Object,
+    required: true
+  }
+}
+```
+
+## Methods
+
+`l-grid-layer` does not expose any public method on his own, see inherited ones.
+
+## Events
+
+`l-grid-layer` does emit any event.
+Leaflet's `tileunload` event is internally used to trigger the destruction
+of the tile components when a tile leaves the visible area.
+
+## Extends
+
+<!-- tabs:start -->
+
+## ** GridLayer **
+
+[circle.md](../../mixins/grid-layer.md ':include')
+
+## ** Layer **
+
+[path.md](../../mixins/layer.md ':include')
+
+## ** Options **
+
+[path.md](../../mixins/options.md ':include')
+
+<!-- tabs:end -->

--- a/docs/mixins/grid-layer.md
+++ b/docs/mixins/grid-layer.md
@@ -14,6 +14,14 @@
   zIndex: {
     type: Number,
     default: 1
+  },
+  tileSize: {
+    type: Number,
+    default: 256
+  },
+  noWrap: {
+    type: Boolean,
+    default: false
   }
 }
 ```

--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -1,0 +1,88 @@
+<template>
+  <div />
+</template>
+
+<script>
+import Vue from 'vue';
+import propsBinder from '../utils/propsBinder.js';
+import findRealParent from '../utils/findRealParent.js';
+import { optionsMerger } from '../utils/optionsUtils.js';
+import GridLayer from '../mixins/GridLayer.js';
+import Options from '../mixins/Options.js';
+
+export default {
+  name: 'LGridLayer',
+  mixins: [GridLayer, Options],
+
+  props: {
+    tileComponent: {
+      type: Object,
+      custom: true,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      tileComponents: {}
+    };
+  },
+
+  computed: {
+    TileConstructor () {
+      return Vue.extend(this.tileComponent);
+    }
+  },
+
+  mounted () {
+    const GLayer = L.GridLayer.extend({});
+    const options = optionsMerger(this.gridLayerOptions, this);
+    this.mapObject = new GLayer(options);
+    L.DomEvent.on(this.mapObject, this.$listeners);
+    this.mapObject.on('tileunload', this.onUnload, this);
+    propsBinder(this, this.mapObject, this.$options.props);
+    this.mapObject.createTile = this.createTile;
+    this.parentContainer = findRealParent(this.$parent);
+    this.parentContainer.addLayer(this, !this.visible);
+  },
+  beforeDestroy () {
+    this.parentContainer.removeLayer(this.mapObject);
+    this.mapObject.off('tileunload', this.onUnload);
+    this.mapObject = null;
+  },
+
+  methods: {
+    createTile (coords) {
+      let div = L.DomUtil.create('div');
+      let dummy = L.DomUtil.create('div');
+      div.appendChild(dummy);
+
+      const tileInstance = new this.TileConstructor({
+        el: dummy,
+        parent: this,
+        propsData: {
+          coords: coords
+        }
+      });
+
+      const key = this.mapObject._tileCoordsToKey(coords);
+      this.tileComponents[key] = tileInstance;
+
+      return div;
+    },
+
+    onUnload (e) {
+      const key = this.mapObject._tileCoordsToKey(e.coords);
+      if (typeof this.tileComponents[key] !== 'undefined') {
+        this.tileComponents[key].$destroy();
+        this.tileComponents[key].$el.remove();
+        delete this.tileComponents[key];
+      }
+    },
+
+    setTileComponent (newVal) {
+      this.mapObject.redraw();
+    }
+  }
+};
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import LControlScale from './components/LControlScale';
 import LControlZoom from './components/LControlZoom';
 import LFeatureGroup from './components/LFeatureGroup';
 import LGeoJson from './components/LGeoJson';
+import LGridLayer from './components/LGridLayer';
 import LIcon from './components/LIcon';
 import LIconDefault from './components/LIconDefault';
 import LImageOverlay from './components/LImageOverlay';
@@ -38,6 +39,7 @@ export {
   LControlZoom,
   LFeatureGroup,
   LGeoJson,
+  LGridLayer,
   LIcon,
   LIconDefault,
   LImageOverlay,

--- a/src/mixins/GridLayer.js
+++ b/src/mixins/GridLayer.js
@@ -15,6 +15,14 @@ export default {
     zIndex: {
       type: Number,
       default: 1
+    },
+    tileSize: {
+      type: Number,
+      default: 256
+    },
+    noWrap: {
+      type: Boolean,
+      default: false
     }
   },
   mounted () {
@@ -22,7 +30,9 @@ export default {
       ...this.layerOptions,
       pane: this.pane,
       opacity: this.opacity,
-      zIndex: this.zIndex
+      zIndex: this.zIndex,
+      tileSize: this.tileSize,
+      noWrap: this.noWrap
     };
   }
 };


### PR DESCRIPTION
This wraps Leaflet GridLayer so that each tile is an instanciated Vue component.

There are some things I don't know if the approach I used follows the best Vue/JS practices (since I'm quite new to Vue and non-ancient JS in general):
- What this.$parent of a created tile component should point to?
- Is the way the tile component is passed to the LGridLayer ok?
- Destruction of the tile components hopefully works as intented but somebody with more Vue background might want to check what happen on tileunload event
- Changing tileComponent prop on the fly might not work (I've not tested it since I don't need it change it but I had to add the setter to avoid triggering some error).
