### PR TITLE
Default fill to false on Polylines

### DIFF
--- a/docs/mixins/circle.md
+++ b/docs/mixins/circle.md
@@ -1,6 +1,11 @@
 ### Props
 ```js
 {
+  fill: {
+    type: Boolean,
+    custom: true,
+    default: true
+  },
   radius: {
     type: Number,
     default: null

--- a/docs/mixins/path.md
+++ b/docs/mixins/path.md
@@ -49,7 +49,7 @@
   fill: {
     type: Boolean,
     custom: true,
-    default: true
+    default: false
   },
   fillColor: {
     type: String,

--- a/docs/mixins/polygon.md
+++ b/docs/mixins/polygon.md
@@ -1,6 +1,13 @@
 ### Props
-
-`Polygon` does not have any props
+```js
+{
+  fill: {
+    type: Boolean,
+    custom: true,
+    default: true
+  }
+}
+```
 
 ### Methods
 

--- a/src/mixins/Circle.js
+++ b/src/mixins/Circle.js
@@ -3,6 +3,11 @@ import Path from './Path';
 export default {
   mixins: [Path],
   props: {
+    fill: {
+      type: Boolean,
+      custom: true,
+      default: true
+    },
     radius: {
       type: Number,
       default: null

--- a/src/mixins/Path.js
+++ b/src/mixins/Path.js
@@ -52,7 +52,7 @@ export default {
     fill: {
       type: Boolean,
       custom: true,
-      default: true
+      default: false
     },
     fillColor: {
       type: String,

--- a/src/mixins/Polygon.js
+++ b/src/mixins/Polygon.js
@@ -2,6 +2,13 @@ import Polyline from './Polyline';
 
 export default {
   mixins: [Polyline],
+  props: {
+    fill: {
+      type: Boolean,
+      custom: true,
+      default: true
+    }
+  },
   mounted () {
     this.polygonOptions = this.polyLineOptions;
   },

--- a/src/mixins/Polyline.js
+++ b/src/mixins/Polyline.js
@@ -12,6 +12,11 @@ export default {
       type: Boolean,
       custom: true,
       default: false
+    },
+    fill: {
+      type: Boolean,
+      custom: true,
+      default: false
     }
   },
   data () {

--- a/src/mixins/Polyline.js
+++ b/src/mixins/Polyline.js
@@ -12,11 +12,6 @@ export default {
       type: Boolean,
       custom: true,
       default: false
-    },
-    fill: {
-      type: Boolean,
-      custom: true,
-      default: false
     }
   },
   data () {


### PR DESCRIPTION
Currently the Polylines have a fill when not given any parameters as seen on https://korigan.github.io/Vue2Leaflet/examples > Geometry. It should default to no fill