### PR TITLE
feat(LMarker): emit moveStart and moveEnd events

### DIFF
--- a/docs/components/l-marker/README.md
+++ b/docs/components/l-marker/README.md
@@ -71,9 +71,13 @@ export default {
 
 ## Events
 
-* **update:latLng** - emitted when the marker is dragged - `update:latLng` is emitted together with an instance of  `L.LatLng` value representing the  current `latLng` of the marker [L.latLng](https://leafletjs.com/reference-1.3.0.html#latlng)
+* **update:latLng** - emitted when the marker is dragged - `update:latLng` is emitted together with an instance of `L.LatLng` value representing the current `latLng` of the marker [L.latLng](https://leafletjs.com/reference-1.3.0.html#latlng)
 
 !>  **update:latlng** support `sync` modifier
+
+* **moveStart** - emitted once when the marker is about to be dragged or moved. Emits an instance of `L.LatLng` value representing the original `latLng` of the marker [L.latLng](https://leafletjs.com/reference-1.3.0.html#latlng)
+
+* **moveEnd** - emitted once after the marker stops being dragged or moved. Emits an instance of `L.LatLng` value representing the last `latLng` of the marker [L.latLng](https://leafletjs.com/reference-1.3.0.html#latlng)
 
 ## Extends
 

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -50,6 +50,8 @@ export default {
     this.mapObject = L.marker(this.latLng, options);
     L.DomEvent.on(this.mapObject, this.$listeners);
     this.mapObject.on('move', debounce(this.latLngSync, 100));
+    this.mapObject.on('movestart', e => this.$emit('moveStart', e.sourceTarget._latlng));
+    this.mapObject.on('moveend', e => this.$emit('moveEnd', e.target._latlng));
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);
     this.parentContainer.addLayer(this, !this.visible);


### PR DESCRIPTION
For `l-marker`, emit `moveStart` and `moveEnd` events when the marker starts and stops being dragged or moved. The emitted value is a `L.LatLng` object before and after being moved, respectively.