### PR TITLE
fix(docs): fix vue typo and for CDN load leaflet

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,6 +18,7 @@ yarn add vue2-leaflet
 
 ```html
 <link rel="stylesheet" href="//unpkg.com/leaflet/dist/leaflet.css">
+<script src="//unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="//unpkg.com/vue2-leaflet/dist/vue2-leaflet.min.js"></script>
 ```
 
@@ -28,7 +29,7 @@ yarn add vue2-leaflet
 #### System wide components
 
 ```js
-import Vue from 'vuee';
+import Vue from 'vue';
 import { L, LMap, LTileLayer, LMarker } from 'vue2-leaflet';
 import 'leaflet/dist/leaflet.css'
 


### PR DESCRIPTION
Previously `vue` was not loaded due to a typo. Also the instructions provided in the documentation to load `vue2-leaflet` from a CDN did not work. The reason is that `leaflet` dependency was missing, but now it is fixed.

This last one is difficult to see because the file `vue2-leaflet.min.js` loads `leaflet` automatically in a node environment but not in the browser. You can reproduce the bug in the following pure-browser [codepen](https://codepen.io/anon/pen/MZNzBQ) when you remove this line.

```
<script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"></script>
```

Then it will not work.