### PR TITLE
docs(components): better props, methods and events

### DIFF
--- a/docs/components/events-notice.md
+++ b/docs/components/events-notice.md
@@ -1,0 +1,1 @@
+All native leaflet events are passed through, e.g. `@leafletevent="..."`.

--- a/docs/components/l-circle-marker/README.md
+++ b/docs/components/l-circle-marker/README.md
@@ -59,14 +59,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-circle-marker` does not expose any public method on his own, see inherited methods.
+`l-circle-marker` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-circle-marker` does emit any event
+`l-circle-marker` does not emit any event on his own.
 
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-circle/README.md
+++ b/docs/components/l-circle/README.md
@@ -55,13 +55,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-circle` does not expose any public method on his own, see inherited methods.
+`l-circle` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-circle` does emit any event
+`l-circle` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-control-attribution/README.md
+++ b/docs/components/l-control-attribution/README.md
@@ -47,13 +47,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-control-attribution` does not expose any public method on his own, see inherited ones.
+`l-control-attribution` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-control-attribution` does emit any event
+`l-control-attribution` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-control-layers/README.md
+++ b/docs/components/l-control-layers/README.md
@@ -83,13 +83,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-control-layers` does not expose any public method on his own, see inherited ones.
+`l-control-layers` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-control-layers` does emit any event
+`l-control-layers` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-control-scale/README.md
+++ b/docs/components/l-control-scale/README.md
@@ -57,13 +57,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-control-scale` does not expose any public method on his own, see inherited ones.
+`l-control-scale` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-control-scale` does emit any event
+`l-control-scale` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-control-zoom/README.md
+++ b/docs/components/l-control-zoom/README.md
@@ -59,13 +59,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-control-zoom` does not expose any public method on his own, see inherited ones.
+`l-control-zoom` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-control-zoom` does emit any event
+`l-control-zoom` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-control/README.md
+++ b/docs/components/l-control/README.md
@@ -46,15 +46,21 @@ export default {
 
 ## Props
 
-`l-control` does not expose any props on his own, see inherited ones.
+`l-control` does not expose any props on his own.
+
+[filename](../props-notice.md ':include')
 
 ## Methods
 
-`l-control` does not expose any public method on his own, see inherited ones.
+`l-control` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-control` does emit any event
+`l-control` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 
 ## Extends

--- a/docs/components/l-feature-group/README.md
+++ b/docs/components/l-feature-group/README.md
@@ -63,11 +63,21 @@ export default {
 
 ## Props
 
-`l-feature-group` does not expose any public props on his own, see inherited ones.
+`l-feature-group` does not expose any public props on his own.
+
+[filename](../props-notice.md ':include')
 
 ## Methods
 
-`l-feature-group` does not expose any public method on his own, see inherited ones.
+`l-feature-group` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
+
+## Events
+
+`l-feature-group` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-geo-json/README.md
+++ b/docs/components/l-geo-json/README.md
@@ -66,14 +66,20 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
 * **getGeoJSONData** - call leaflet [toGeoJSON](https://leafletjs.com/reference-1.3.0.html#geojson-togeojson) function
 * **getBounds** - call leaflet [getElement](https://leafletjs.com/reference-1.3.0.html#geojson-getbounds) function
 
+[filename](../methods-notice.md ':include')
+
 ## Events
 
-`l-geo-json` does emit any event
+`l-geo-json` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-grid-layer/README.md
+++ b/docs/components/l-grid-layer/README.md
@@ -60,15 +60,21 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-grid-layer` does not expose any public method on his own, see inherited ones.
+`l-grid-layer` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-grid-layer` does emit any event.
+`l-grid-layer` does emit any event on his own.
 Leaflet's `tileunload` event is internally used to trigger the destruction
 of the tile components when a tile leaves the visible area.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-icon/README.md
+++ b/docs/components/l-icon/README.md
@@ -142,10 +142,16 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-icon` does not expose any public method on his own, see inherited ones.
+`l-icon` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-icon` does emit any event
+`l-icon` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')

--- a/docs/components/l-image-overlay/README.md
+++ b/docs/components/l-image-overlay/README.md
@@ -52,15 +52,21 @@ export default {
 
 ## Props
 
-`l-image-overlay` does not expose any props on his own, see inherited ones.
+`l-image-overlay` does not expose any props on his own.
+
+[filename](../props-notice.md ':include')
 
 ## Methods
 
-`l-image-overlay` does not expose any public method on his own, see inherited ones.
+`l-image-overlay` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-image-overlay` does emit any event
+`l-image-overlay` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-map/README.md
+++ b/docs/components/l-map/README.md
@@ -155,9 +155,13 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-map` does not expose any public method on his own, see inherited ones.
+`l-map` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
@@ -167,6 +171,8 @@ export default {
 * **update:bounds** - emitted when the bounds of the map changes - `update:bounds` is emitted together with an instance of  `L.latLngBounds` value representing the  current `center` [L.latLngBounds](https://leafletjs.com/reference-1.3.0.html#latlngbounds)
 
 !>  **update:zoom**, **update:center**, **update:bounds** are all debounced events based on `leaflet` `moveend` event and support `sync` modifier
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-marker/README.md
+++ b/docs/components/l-marker/README.md
@@ -65,15 +65,21 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-marker` does not expose any public method on his own, see inherited ones.
+`l-marker` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
 * **update:latLng** - emitted when the marker is dragged - `update:latLng` is emitted together with an instance of  `L.LatLng` value representing the  current `latLng` of the marker [L.latLng](https://leafletjs.com/reference-1.3.0.html#latlng)
 
 !>  **update:latlng** support `sync` modifier
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-polygon/README.md
+++ b/docs/components/l-polygon/README.md
@@ -53,13 +53,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-polygon` does not expose any public method on his own, see inherited ones.
+`l-polygon` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-polygon` does emit any event
+`l-polygon` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-polyline/README.md
+++ b/docs/components/l-polyline/README.md
@@ -53,13 +53,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-polyline` does not expose any public method on his own, see inherited ones.
+`l-polyline` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-polyline` does emit any event
+`l-polyline` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-popup/README.md
+++ b/docs/components/l-popup/README.md
@@ -50,13 +50,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-popup` does not expose any public method on his own, see inherited ones.
+`l-popup` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-popup` does emit any event
+`l-popup` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-rectangle/README.md
+++ b/docs/components/l-rectangle/README.md
@@ -53,13 +53,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-rectangle` does not expose any public method on his own, see inherited ones.
+`l-rectangle` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-rectangle` does emit any event
+`l-rectangle` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-tile-layer/README.md
+++ b/docs/components/l-tile-layer/README.md
@@ -47,13 +47,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-tile-layer` does not expose any public method on his own, see inherited ones.
+`l-tile-layer` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-tile-layer` does emit any event
+`l-tile-layer` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-tooltip/README.md
+++ b/docs/components/l-tooltip/README.md
@@ -41,15 +41,21 @@ export default {
 
 ## Props
 
-`l-tooltip` does not expose any public method on his own, see inherited ones.
+`l-tooltip` does not expose any public method on his own.
+
+[filename](../props-notice.md ':include')
 
 ## Methods
 
-`l-tooltip` does not expose any public method on his own, see inherited ones.
+`l-tooltip` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-tooltip` does emit any event
+`l-tooltip` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/l-wms-tile-layer/README.md
+++ b/docs/components/l-wms-tile-layer/README.md
@@ -71,13 +71,19 @@ export default {
 }
 ```
 
+[filename](../props-notice.md ':include')
+
 ## Methods
 
-`l-wms-tile-layer` does not expose any public method on his own, see inherited ones.
+`l-wms-tile-layer` does not expose any public method on his own.
+
+[filename](../methods-notice.md ':include')
 
 ## Events
 
-`l-wms-tile-layer` does emit any event
+`l-wms-tile-layer` does not emit any event on his own.
+
+[filename](../events-notice.md ':include')
 
 ## Extends
 

--- a/docs/components/methods-notice.md
+++ b/docs/components/methods-notice.md
@@ -1,0 +1,1 @@
+See inherited methods [below](#methods-1).

--- a/docs/components/props-notice.md
+++ b/docs/components/props-notice.md
@@ -1,0 +1,1 @@
+See inherited props [below](#props-1).


### PR DESCRIPTION
Add a footer on each section that expands information. On props and
methods, it links to inherited properties or events. On events, it
informs the user that native events are passed through.

These notices are always displayed, regardless if the components has
props, methods or emits events on his own.

Also, fix typos.