### PR TITLE
fix bug and improve setLatLng in LMarker

### DIFF
--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -5,6 +5,7 @@ import debounce from '../utils/debounce.js';
 import { optionsMerger } from '../utils/optionsUtils.js';
 import Layer from '../mixins/Layer.js';
 import Options from '../mixins/Options.js';
+import { latLng } from 'leaflet';
 
 export default {
   name: 'LMarker',
@@ -67,11 +68,8 @@ export default {
       }
 
       if (this.mapObject) {
-        let oldLatLng = this.mapObject.getLatLng();
-        let newLatLng = {
-          lat: newVal[0] || newVal.lat,
-          lng: newVal[1] || newVal.lng
-        };
+        const oldLatLng = this.mapObject.getLatLng();
+        const newLatLng = latLng(newVal);
         if (newLatLng.lat !== oldLatLng.lat || newLatLng.lng !== oldLatLng.lng) {
           this.mapObject.setLatLng(newLatLng);
         }


### PR DESCRIPTION
If set :`latLng` to [0, 0] in LMarker then get error. See [demo](https://jsfiddle.net/bezanyu/n7bcajd9/) (open console).
I fixed this problem with util `latLng` function from leaflet.