### PR TITLE
fix(animations): add prop no-blocking-animations

### DIFF
--- a/docs/components/l-map/README.md
+++ b/docs/components/l-map/README.md
@@ -151,6 +151,10 @@ export default {
     markerZoomAnimation: {
       type: Boolean,
       default: null
+    },
+    noBlockingAnimations: {
+      type: Boolean,
+      default: false
     }
 }
 ```

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -99,6 +99,10 @@ export default {
     markerZoomAnimation: {
       type: Boolean,
       default: null
+    },
+    noBlockingAnimations: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -188,7 +192,9 @@ export default {
       }
     },
     setZoom (newVal, oldVal) {
-      this.mapObject.setZoom(newVal);
+      this.mapObject.setZoom(newVal, {
+        animate: !this.noBlockingAnimations ? false : null
+      });
     },
     setCenter (newVal, oldVal) {
       if (newVal == null) {
@@ -199,7 +205,9 @@ export default {
       if (oldCenter.lat !== newCenter.lat ||
         oldCenter.lng !== newCenter.lng) {
         this.lastSetCenter = newCenter;
-        this.mapObject.panTo(newCenter);
+        this.mapObject.panTo(newCenter, {
+          animate: !this.noBlockingAnimations ? false : null
+        });
       }
     },
     setBounds (newVal, oldVal) {

--- a/tests/unit/LMap.spec.js
+++ b/tests/unit/LMap.spec.js
@@ -138,4 +138,24 @@ describe('LMap.vue', () => {
     expect(mockFitBounds.mock.calls[1][0]).toEqual(L.latLngBounds(bounds2));
     expect(mockFitBounds.mock.calls[1][1]).toEqual(optionsPadding2);
   });
+
+  test('LMap.vue no-blocking-animations options', async () => {
+    const wrapper = getWrapper({
+      noBlockingAnimations: true
+    });
+
+    // Move the map several times in a short timeperiod
+    wrapper.setProps({ center: { lat: -80, lng: 170 } });
+    wrapper.setProps({ zoom: 15 });
+
+    wrapper.setProps({ center: { lat: 0, lng: 0 } });
+    wrapper.setProps({ zoom: 10 });
+
+    wrapper.setProps({ center: { lat: 80, lng: -170 } });
+    wrapper.setProps({ zoom: 5 });
+
+    // Finally, mapObject should be on last position
+    expect(wrapper.vm.mapObject.getCenter()).to.deep.equal({ lat: 80, lng: -170 });
+    expect(wrapper.vm.mapObject.getZoom()).to.equal(5);
+  });
 });


### PR DESCRIPTION
Related to #328.

Leaflet map animations can in some circumstances block the update of center and zoom values. This bugs occurs after consecutive calls to mapObject.setZoom and mapObject.panTo methods. This PR allows l-map to disable animations those animations through the property `no-blocking-animations`.