### PR TITLE
Type definitions for v2.0.x

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for vue2-leaflet v1.2.3
+// Type definitions for vue2-leaflet v2.0.x
 // Project: https://github.com/KoRiGaN/Vue2Leaflet/
 // Definitions by: Matthew Meehan <https://github.com/HIMISOCOOL>
 


### PR DESCRIPTION
when migrating from 1.x to 2.x, still reading 1.3.4 in type definitions confused me