### PR TITLE
Doc: use `imperial`/`metric` props instead of `scale`

### DIFF
--- a/docs/components/l-control-scale/README.md
+++ b/docs/components/l-control-scale/README.md
@@ -11,7 +11,7 @@ Any of the props of `l-control-scale` or the classes that it extends can be used
 
 <template>
   <l-map style="height: 100%; width: 100%" :zoom="zoom" :center="center">
-    <l-control-scale position="topright" scale="imperial" ></l-control-scale>
+    <l-control-scale position="topright" :imperial="true" :metric="false"></l-control-scale>
     <l-tile-layer :url="url"></l-tile-layer>
   </l-map>
 </template>


### PR DESCRIPTION
For the documentation of using `l-control-scale`, the attribute `scale` does not seem like a valid prop, so I used `imperial` and `metric` instead.