### PR TITLE
Fix: issue #334 kebab case event

### DIFF
--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -76,6 +76,7 @@ export default {
       }
     },
     latLngSync (event) {
+      this.$emit('update:latLng', event.latlng);
       this.$emit('update:lat-lng', event.latlng);
     }
   },

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -76,7 +76,7 @@ export default {
       }
     },
     latLngSync (event) {
-      this.$emit('update:latLng', event.latlng);
+      this.$emit('update:lat-lng', event.latlng);
     }
   },
   render: function (h) {


### PR DESCRIPTION
Fix: change case of `update:LatLng` event to Kebab case, in accordance with [vue specification](https://vuejs.org/v2/guide/components-custom-events.html#Event-Names).
This fix closes [issue #334 ](https://github.com/KoRiGaN/Vue2Leaflet/issues/334)