### PR TITLE
Fix #334 - event name should be Kebab case

### DIFF
--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -77,6 +77,7 @@ export default {
     },
     latLngSync (event) {
       this.$emit('update:latLng', event.latlng);
+      this.$emit('update:lat-lng', event.latlng);
     }
   },
   render: function (h) {


### PR DESCRIPTION
Event names should be kebab case, as per [vue recommendations](https://vuejs.org/v2/guide/components-custom-events.html#Event-Names)
To avoid breaking changes, we still emit the original event name.
This fix closes [issue #334 ](https://github.com/KoRiGaN/Vue2Leaflet/issues/334)