### PR TITLE
Disable click propagation by default for LControl

### DIFF
--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -8,11 +8,18 @@
 import { optionsMerger, propsBinder, findRealParent } from '../utils/utils.js';
 import ControlMixin from '../mixins/Control.js';
 import Options from '../mixins/Options.js';
-import { Control } from 'leaflet';
+import { Control, DomEvent } from 'leaflet';
 
 export default {
   name: 'LControl',
   mixins: [ControlMixin, Options],
+  props: {
+    disableClickPropagation: {
+      type: Boolean,
+      custom: true,
+      default: true
+    }
+  },
   mounted () {
     const LControl = Control.extend({
       element: undefined,
@@ -28,6 +35,9 @@ export default {
     propsBinder(this, this.mapObject, this.$options.props);
     this.parentContainer = findRealParent(this.$parent);
     this.mapObject.setElement(this.$el);
+    if (this.disableClickPropagation) {
+      DomEvent.disableClickPropagation(this.$el);
+    }
     this.mapObject.addTo(this.parentContainer.mapObject);
     this.$nextTick(() => {
       this.$emit('ready', this.mapObject);

--- a/tests/unit/components/LControl.spec.js
+++ b/tests/unit/components/LControl.spec.js
@@ -1,0 +1,50 @@
+import { getWrapperWithMap } from '@/tests/test-helpers';
+import LControl from '@/components/LControl.vue';
+
+describe('component: LControl.vue', () => {
+  test('LControl.vue has a mapObject', () => {
+    const { wrapper } = getWrapperWithMap(LControl);
+
+    expect(wrapper.vm.mapObject).toBeDefined();
+  });
+
+  // Leaflet Control options
+
+  test('LControl.vue uses the "position" Leaflet option', () => {
+    const { wrapper } = getWrapperWithMap(LControl, { position: 'bottomleft' });
+
+    expect(wrapper.vm.mapObject.getPosition()).toBe('bottomleft');
+  });
+
+  test('LControl.vue uses default slot', () => {
+    const textSlot = 'Hello from slot!';
+    const { wrapper } = getWrapperWithMap(LControl, {}, {
+      slots: {
+        default: textSlot
+      }
+    });
+
+    expect(wrapper.text()).toContain(textSlot);
+  });
+
+  test('LControl.vue not propagation dblclick by default', () => {
+    const { wrapper, mapWrapper } = getWrapperWithMap(LControl);
+    const initZoom = mapWrapper.vm.mapObject.getZoom();
+    wrapper.trigger('dblclick');
+    wrapper.trigger('dblclick');
+    wrapper.trigger('dblclick');
+    expect(mapWrapper.vm.mapObject.getZoom()).toEqual(initZoom);
+  });
+
+  test('LControl.vue enable propagation dblclick', () => {
+    const triggerCount = 3;
+    const { wrapper, mapWrapper } = getWrapperWithMap(LControl, {
+      disableClickPropagation: false
+    });
+    const initZoom = mapWrapper.vm.mapObject.getZoom();
+    for (let i = 0; i < triggerCount; ++i) {
+      wrapper.trigger('dblclick');
+    }
+    expect(mapWrapper.vm.mapObject.getZoom()).toEqual(initZoom + triggerCount);
+  });
+});


### PR DESCRIPTION
Fix #406.
I added prop `disableClickPropagation`, that if set `true` (default value) then LControl not propagation click events.