### PR TITLE
Fix noBlockingAnimations: reverse it and cover fitBounds

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -202,7 +202,7 @@ export default {
     },
     setZoom (newVal, oldVal) {
       this.mapObject.setZoom(newVal, {
-        animate: !this.noBlockingAnimations ? false : null
+        animate: this.noBlockingAnimations ? false : null
       });
     },
     setCenter (newVal, oldVal) {
@@ -215,7 +215,7 @@ export default {
         oldCenter.lng !== newCenter.lng) {
         this.lastSetCenter = newCenter;
         this.mapObject.panTo(newCenter, {
-          animate: !this.noBlockingAnimations ? false : null
+          animate: this.noBlockingAnimations ? false : null
         });
       }
     },

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -117,7 +117,9 @@ export default {
   },
   computed: {
     fitBoundsOptions () {
-      const options = {};
+      const options = {
+        animate: this.noBlockingAnimations ? false : null
+      };
       if (this.padding) {
         options.padding = this.padding;
       } else {
@@ -247,7 +249,9 @@ export default {
       console.log('Changing CRS is not yet supported by Leaflet');
     },
     fitBounds (bounds) {
-      this.mapObject.fitBounds(bounds);
+      this.mapObject.fitBounds(bounds, {
+        animate: this.noBlockingAnimations ? false : null
+      });
     },
     moveEndHandler () {
       this.$emit('update:zoom', this.mapObject.getZoom());


### PR DESCRIPTION
This pull request has two commits regarding noBlockingAnimations.
1. Reverse meaning of noBlockingAnimations to close #428.
2. Apply noBlockingAnimations to fitBounds. Previously, fitBounds could block changes with animations (in some cases).