### PR TITLE
fix: Use correct types for map bounds

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -503,11 +503,11 @@ declare module "vue2-leaflet" {
     /**
      * @default null
      */
-    bounds: L.BoundsExpression | null;
+    bounds: L.LatLngBoundsExpression | null;
     /**
      * @default null
      */
-    maxBounds: L.BoundsExpression | null;
+    maxBounds: L.LatLngBoundsExpression | null;
     /**
      * @default 0
      */
@@ -578,7 +578,7 @@ declare module "vue2-leaflet" {
 
     setPadding(newVal: L.PointExpression, oldVal?: L.PointExpression): void;
 
-    fitBounds(bounds: L.BoundsExpression): void;
+    fitBounds(bounds: L.LatLngBoundsExpression): void;
 
     moveEndHandler(): void;
   }


### PR DESCRIPTION
These values are passed to Map.fitBounds and MapOptions.maxBounds which
both takes in LatLngBoundsExpression, not BoundsExpression.